### PR TITLE
fix: prevent duplicate years in selector

### DIFF
--- a/my budget code
+++ b/my budget code
@@ -396,6 +396,7 @@
         function populateYearSelector() {
             const currentYear = new Date().getFullYear();
             const startYear = 2020;
+            yearSelector.innerHTML = '';
             for (let year = currentYear + 1; year >= startYear; year--) {
                 const option = document.createElement('option');
                 option.value = year;


### PR DESCRIPTION
## Summary
- reset year dropdown before populating to avoid duplicates when auth state changes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689514752e1883219c6abd79b03d23b3